### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: '0 6 1 * *'  # once a month in the morning
 
+# Change default shell to bash for all OS:
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Use the `flake8` tool to check for syntax errors
   flake8:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,6 +177,12 @@ jobs:
       id: vars
       run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
 
+    - name: Generate changelog
+      id: changelog
+      uses: metcalfc/changelog-generator@v3.0.0
+      with:
+        myToken: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -187,4 +193,8 @@ jobs:
         release_name: Version ${{ steps.vars.outputs.tag }}
         body: |
           Version ${{ steps.vars.outputs.tag }}
+
+          Changelog
+          ---------
+          ${{ steps.changelog.outputs.changelog }}
         draft: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,25 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.7
-
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-py3.7-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-py3.7-
-          ${{ runner.os }}-pip-
+        cache: 'pip'
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
+        python -m pip install --upgrade pip wheel setuptools
         grep "numpy" requirements.txt | xargs -I {} pip install "{}"
         pip install -r requirements.txt
 
@@ -55,14 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
-        include:
-        - os: ubuntu-latest
-          pippath: ~/.cache/pip
-        - os: macos-latest
-          pippath: ~/Library/Caches/pip
-        - os: windows-latest
-          pippath: ~\AppData\Local\pip\Cache
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -72,7 +57,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -90,23 +75,15 @@ jobs:
       run: git lfs pull
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        path: ${{ matrix.pippath }}
-        key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-py${{ matrix.python-version }}-
-          ${{ runner.os }}-pip-
+        cache: 'pip'
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
-        grep "numpy" requirements.txt | xargs -I {} pip install "{}"
+        python -m pip install --upgrade pip wheel setuptools
+        grep "^numpy" requirements.txt | xargs -I {} pip install "{}"
         pip install -r requirements.txt
         pip install codecov pytest-cov
 
@@ -125,28 +102,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: false
 
     - name: Setup Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.7
-
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-py3.7-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-py3.7-
-          ${{ runner.os }}-pip-
+        cache: 'pip'
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
-        grep "numpy" requirements.txt | xargs -I {} pip install "{}"
+        python -m pip install --upgrade pip wheel setuptools
+        grep "^numpy" requirements.txt | xargs -I {} pip install "{}"
         grep -v -E "^mpi4py|^tensorflow|^xgboost" requirements.txt > requirements.tmp.txt
         pip install -r requirements.tmp.txt
         pip install -r docs/requirements-docs.txt
@@ -167,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -185,23 +154,15 @@ jobs:
       run: git lfs pull
 
     - name: Setup Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.7
-
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-py3.7-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-py3.7-
-          ${{ runner.os }}-pip-
+        cache: 'pip'
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
-        grep "numpy" requirements.txt | xargs -I {} pip install "{}"
+        python -m pip install --upgrade pip wheel setuptools
+        grep "^numpy" requirements.txt | xargs -I {} pip install "{}"
         pip install -r requirements.txt
 
     - name: Update VERSION file

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
       run: pytest --cov
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         env_vars: OS,PYTHON
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,11 @@ flake8
 flake8-tabs >= 2.3.2
 flake8-builtins
 flake8-logging-format
-numpy == 1.19.5
-scipy == 1.5.4
-matplotlib == 3.3.2
-astropy == 4.1
-Bottleneck == 1.3.2
-statsmodels == 0.12.1
+numpy == 1.21.4
+scipy == 1.7.3
+matplotlib == 3.5.2
+astropy == 5.1.0 ; python_version > '3.7'
+astropy == 4.3.1 ; python_version <= '3.7'
+Bottleneck == 1.3.4
+statsmodels == 0.13.2
 tqdm


### PR DESCRIPTION
Update dependencies and testing setup. This follows the changes recently made in the photometry module.